### PR TITLE
Use fully-qualified names in macro quasiquotes

### DIFF
--- a/api/src/test/scala/com/example/unrelated/SchemaMacroNamesSpec.scala
+++ b/api/src/test/scala/com/example/unrelated/SchemaMacroNamesSpec.scala
@@ -1,0 +1,25 @@
+package com.example.unrelated
+
+import json.{Json, Schema}
+import org.scalatest._
+
+/** This spec checks that the macro works even when names from
+  * `com.github.andyglow.jsonschema` are not in scope.
+  */
+class SchemaMacroNamesSpec extends WordSpec {
+  import SchemaNamesSpec._
+
+  "Schema" should {
+
+    "generate a schema with a reference to another schema" in {
+      implicit val fooSchema: Schema[Foo] = Json.schema[Foo]
+      implicit val barSchema: Schema[Bar] = Json.schema[Bar] // should compile
+    }
+
+  }
+}
+
+private object SchemaNamesSpec {
+  final case class Foo(s: String)
+  final case class Bar(foo: Foo)
+}

--- a/macros/src/main/scala/com/github/andyglow/jsonschema/TypeSignatureMacro.scala
+++ b/macros/src/main/scala/com/github/andyglow/jsonschema/TypeSignatureMacro.scala
@@ -19,6 +19,6 @@ object TypeSignatureMacro {
       localName + s"[${tpe.typeArgs map { _.typeSymbol.fullName } mkString ","}]"
     }
 
-    q"TypeSignature[$tpe]($name)"
+    q"_root_.com.github.andyglow.jsonschema.TypeSignature[$tpe]($name)"
   }
 }


### PR DESCRIPTION
Use fully-qualified names in macro quasiquotes to
ensure that the correct type is always used and that
API users never need to import any types for the
macros to work.

Fixes a bug where users had to import
`com.github.andyglow.jsonschema.TypeSignature`
in order to use `json.Json.schema`.