### PR TITLE
Make TypeHint Serializable

### DIFF
--- a/core/src/main/scala/json/schema/typeHint.scala
+++ b/core/src/main/scala/json/schema/typeHint.scala
@@ -2,4 +2,4 @@ package json.schema
 
 import scala.annotation.StaticAnnotation
 
-final class typeHint[T] extends StaticAnnotation
+final class typeHint[T] extends StaticAnnotation with Serializable


### PR DESCRIPTION
Make typeHint annotation Serializable, because it is necessary to serialize annotated object.
