### PR TITLE
allow making non-empty object definitions a free (aka partial structure definition or `padditionalProperties=true`)

### DIFF
--- a/README.md
+++ b/README.md
@@ -533,9 +533,19 @@ implicit val metaSchema: json.Schema[JsObject] = json.Schema.`object`.Free[JsObj
 // or alternatively define a metadata Predef in case you need this to not go to definition section of json-schema
 // implicit val metaPredef: json.schema.Predef[JsObject] = json.schema.Predef(json.Schema.`object`.Free[JsObject]())
 
-// person schema
-val personSchema: json.Schema[Person] = Json.schema[Person]
+// payload schema
+val payloadSchema: json.Schema[Payload] = Json.schema[Payload]
 ``` 
+
+Also, there is API to make object definition Free (and vice versa, a Free definition Strict)
+```scala
+case class Person(name: String, age: Int)
+val personSchema = Json.objectSchema[Person]
+val freePersonSchema = personSchema.free
+val strictPersonSchema = freePersonSchema.strict
+
+strictPersonSchema == personSchema // equal
+```
 
 ## Joda Time
 Joda Time Support allows you to use joda-time classes within your models.

--- a/api/src/test/scala/com/github/andyglow/jsonschema/AsDraft04Spec.scala
+++ b/api/src/test/scala/com/github/andyglow/jsonschema/AsDraft04Spec.scala
@@ -24,7 +24,7 @@ class AsDraft04Spec extends AnyWordSpec {
       AsValue.schema(
         `object`(
           Field("foo" , `string`),
-          Field("meta", `object`.Free[Any]()),
+          Field("meta", `object`(Field("owner" , `string`)).free),
           Field("uuid", `string`(`string`.Format.`uuid`)),
           Field("bar" , `integer`, required = false),
           Field("baz" , `def`[Boolean]("my-bool", `boolean`))),
@@ -35,7 +35,7 @@ class AsDraft04Spec extends AnyWordSpec {
       "required" -> arr("foo", "meta", "baz", "uuid"),
       "properties" -> obj(
         "foo"  -> obj("type" -> "string"),
-        "meta" -> obj("type" -> "object", "additionalProperties" -> true),
+        "meta" -> obj("type" -> "object", "properties" -> obj("owner" -> obj("type" -> "string")), "required" -> arr("owner"), "additionalProperties" -> true),
         "uuid" -> obj("type" -> "string", "pattern" -> Constants.RegEx.uuid),
         "bar"  -> obj("type" -> "integer"),
         "baz"  -> obj(f"$$ref" -> "#/definitions/my-bool")),

--- a/core/src/main/scala/json/Schema.scala
+++ b/core/src/main/scala/json/Schema.scala
@@ -288,12 +288,30 @@ object Schema {
       }
       sb.setLength(sb.length - 1) // drop last comma
       sb append ")"
+
+      if (this.isInstanceOf[Free]) { sb append " additionalProperties=true" }
+    }
+
+    def free: `object`[T] with Free = {
+      val self = this
+      new `object`[T](fields) with Free {
+        type Type = T
+        def strict: `object`[T] = self
+      }
     }
   }
   final object `object` {
-    sealed trait Free { this: `object`[_] => }
+    sealed trait Free { this: `object`[_] =>
+      type Type
+      def strict: `object`[Type]
+    }
     final object Free {
-      def apply[T](): `object`[T] with Free = new `object`[T](Set.empty) with Free
+      def apply[T](): `object`[T] with Free = {
+        new `object`[T](Set.empty) with Free {
+          type Type = T
+          override def strict: `object`[T] = new `object`[T](Set.empty)
+        }
+      }
     }
     final case class Field[T](
       name: String,


### PR DESCRIPTION
resolves #164 