### PR TITLE
Describe how to enable enumeratum support in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Inspired by Coursera Autoschema but uses `Scala Macros` instead of `Java Reflect
         - `eu.timepit.refined.collection.MaxSize`
         - `eu.timepit.refined.collection.Empty`
         - `eu.timepit.refined.collection.NonEmpty`
-- with Enumeratum module enabled
+- with Enumeratum module enabled with `import com.github.andyglow.jsonschema.EnumeratumSupport._`
     - `enums` based on `EnumEntry`/`Enum`            
     - `enums` based on `ValueEnumEntry`/`ValueEnum`            
 - Misc


### PR DESCRIPTION
Reminder in Readme on how to enable enumeratum support.

Note:  I also found that my IDE could incorrectly mark the import as unused and delete it, in that case it would be necessary to extend LowPriorityEnumSupport as a workaround: @andyglow, should I mention that in the readme?