### PR TITLE
remove `final` modifiers

### DIFF
--- a/api/src/test/scala-2.12/com/github/andyglow/jsonschema/NoneForDefaultValueSpec.scala
+++ b/api/src/test/scala-2.12/com/github/andyglow/jsonschema/NoneForDefaultValueSpec.scala
@@ -9,7 +9,7 @@ import com.github.andyglow.jsonschema.{ model => case0 }
 
 object NoneForDefaultValueCases {
 
-  final object case1 {
+  object case1 {
     case class Foo(value: Option[String] = None)
   }
 }

--- a/api/src/test/scala-2.13/com/github/andyglow/jsonschema/NoneForDefaultValueSpec.scala
+++ b/api/src/test/scala-2.13/com/github/andyglow/jsonschema/NoneForDefaultValueSpec.scala
@@ -9,7 +9,7 @@ import com.github.andyglow.jsonschema.{ model => case0 }
 
 object NoneForDefaultValueCases {
 
-  final object case1 {
+  object case1 {
     case class Foo(value: Option[String] = None)
   }
 }

--- a/api/src/test/scala/com/github/andyglow/jsonschema/DiscriminatorSpec.scala
+++ b/api/src/test/scala/com/github/andyglow/jsonschema/DiscriminatorSpec.scala
@@ -13,18 +13,18 @@ import JsonMatchers._
 object DiscriminatorSpec {
 
   // phantom
-  final object case0 {
+  object case0 {
     @discriminator sealed trait Root
-    final object Root {
+    object Root {
       final case class Member1(value: Int) extends Root
       final case class Member2(value: String) extends Root
     }
   }
 
   // not a phantom
-  final object case1 {
+  object case1 {
     @discriminator(field = "type", phantom = false) sealed trait Root
-    final object Root {
+    object Root {
       final case class Member1(`type`: String, value: Int) extends Root
       final case class Member2(`type`: String, value: String) extends Root
     }
@@ -33,36 +33,36 @@ object DiscriminatorSpec {
   // not a phantom, should fail because discriminator field is both
   // - not a phantom
   // - and not present
-  final object case2 {
+  object case2 {
     @discriminator(field = "tpe", phantom = false) sealed trait Root
-    final object Root {
+    object Root {
       final case class Member1(`type`: String, value: Int) extends Root
       final case class Member2(`type`: String, value: String) extends Root
     }
   }
 
   // not a phantom, non-standard discrimination field
-  final object case3 {
+  object case3 {
     @discriminator(field = "tpe", phantom = false) sealed trait Root
-    final object Root {
+    object Root {
       final case class Member1(tpe: String, value: Int) extends Root
       final case class Member2(tpe: String, value: String) extends Root
     }
   }
 
   // specific discriminator keys
-  final object case4 {
+  object case4 {
     @discriminator sealed trait Root
-    final object Root {
+    object Root {
       @discriminatorKey("m1") final case class Member1(value: Int) extends Root
       @discriminatorKey("m2") final case class Member2(value: String) extends Root
     }
   }
 
   // definition + specific discriminator keys
-  final object case5 {
+  object case5 {
     @discriminator sealed trait Root
-    final object Root {
+    object Root {
       @definition("m1") @discriminatorKey("m1") final case class Member1(value: Int) extends Root
       @definition("m2") @discriminatorKey("m2") final case class Member2(value: String) extends Root
     }

--- a/api/src/test/scala/com/github/andyglow/jsonschema/RecursiveTypesSpec.scala
+++ b/api/src/test/scala/com/github/andyglow/jsonschema/RecursiveTypesSpec.scala
@@ -11,19 +11,19 @@ import org.scalatest.wordspec._
 // comes first because otherwise it fails on directKnownSubclass resolution
 object RecursiveTypesSpec {
 
-  final object case1 {
+  object case1 {
     final case class SList(head: String, tail: Option[SList])
   }
 
-  final object case2 {
+  object case2 {
     sealed trait Node
-    final object Node {
+    object Node {
       final case class Element(tag: String, children: List[Node]) extends Node
       final case class Text(content: String) extends Node
     }
   }
 
-  final object case3 {
+  object case3 {
     final case class LList[T](head: T, tail: Option[LList[T]])
     final case class User(id: String, friends: LList[String])
   }

--- a/core/src/main/scala/json/Schema.scala
+++ b/core/src/main/scala/json/Schema.scala
@@ -119,7 +119,7 @@ object Schema {
     override def jsonType: String = "boolean"
     override def toString: String = ToString(_ append "boolean")
   }
-  final object `boolean` extends `boolean`
+  object `boolean` extends `boolean`
 
   // +------------
   // | Integer
@@ -132,7 +132,7 @@ object Schema {
     override def jsonType: String = "integer"
     override def toString: String = ToString(_ append "integer")
   }
-  final object `integer` extends `integer`
+  object `integer` extends `integer`
 
   // +------------
   // | Number
@@ -145,7 +145,7 @@ object Schema {
     override def jsonType: String = "number"
     override def toString: String = ToString(_ append "number")
   }
-  final object `number` {
+  object `number` {
     def apply[T: Numeric]: `number`[T] = new `number`[T]
   }
 
@@ -171,25 +171,25 @@ object Schema {
       }
     }
   }
-  final object `string` extends `string`[String](None) {
+  object `string` extends `string`[String](None) {
     def apply[T]: `string`[T] = new `string`[T](None)
     def apply[T](format: Format): `string`[T] = new `string`[T](Some(format))
     trait Format extends Product
     object Format {
-      final case object `date` extends Format
-      final case object `time` extends Format
-      final case object `date-time` extends Format    // Date representation, as defined by RFC 3339, section 5.6.
-      final case object `email` extends Format        // Internet email address, see RFC 5322, section 3.4.1.
-      final case object `hostname` extends Format     // Internet host name, see RFC 1034, section 3.1.
-      final case object `ipv4` extends Format         // Internet host name, see RFC 1034, section 3.1.
-      final case object `ipv6` extends Format         // IPv6 address, as defined in RFC 2373, section 2.2.
-      final case object `uri` extends Format          // A universal resource identifier (URI), according to RFC3986.
+      case object `date` extends Format
+      case object `time` extends Format
+      case object `date-time` extends Format    // Date representation, as defined by RFC 3339, section 5.6.
+      case object `email` extends Format        // Internet email address, see RFC 5322, section 3.4.1.
+      case object `hostname` extends Format     // Internet host name, see RFC 1034, section 3.1.
+      case object `ipv4` extends Format         // Internet host name, see RFC 1034, section 3.1.
+      case object `ipv6` extends Format         // IPv6 address, as defined in RFC 2373, section 2.2.
+      case object `uri` extends Format          // A universal resource identifier (URI), according to RFC3986.
 
       // added in 2019-09
-      final case object `duration` extends Format     // The duration format is from the ISO 8601 ABNF as given in Appendix A of RFC 3339
-      final case object `idn-hostname` extends Format // Use RFC 1123 instead of RFC 1034; this allows for a leading digit,
+      case object `duration` extends Format     // The duration format is from the ISO 8601 ABNF as given in Appendix A of RFC 3339
+      case object `idn-hostname` extends Format // Use RFC 1123 instead of RFC 1034; this allows for a leading digit,
                                                       // `hostname` is also RFC 1123 since 2019-09
-      final case object `uuid` extends Format         // A string instance is valid against this attribute if it is a valid string representation of a UUID, according to RFC4122
+      case object `uuid` extends Format         // A string instance is valid against this attribute if it is a valid string representation of a UUID, according to RFC4122
     }
   }
 
@@ -242,20 +242,20 @@ object Schema {
       sb append ")"
     }
   }
-  final object `dictionary` {
+  object `dictionary` {
     abstract class KeyPattern[T](val pattern: String)
-    final object KeyPattern {
+    object KeyPattern {
       def mk[T](pattern: String): KeyPattern[T] = new KeyPattern[T](pattern) {}
       def forEnum[T](vals: Iterable[String]): KeyPattern[T] = {
         require(vals.nonEmpty)
         mk[T](vals.toList.distinct.sorted.mkString("^(?:", "|", ")$"))
       }
-      implicit final object StringKeyPattern extends KeyPattern[String]("^.*$")
-      implicit final object CharKeyPattern extends KeyPattern[Char]("^.{1}$")
-      implicit final object ByteKeyPattern extends KeyPattern[Byte]("^[0-9]+$")
-      implicit final object ShortKeyPattern extends KeyPattern[Short]("^[0-9]+$")
-      implicit final object IntKeyPattern extends KeyPattern[Int]("^[0-9]+$")
-      implicit final object LongKeyPattern extends KeyPattern[Long]("^[0-9]+$")
+      implicit object StringKeyPattern extends KeyPattern[String]("^.*$")
+      implicit object CharKeyPattern extends KeyPattern[Char]("^.{1}$")
+      implicit object ByteKeyPattern extends KeyPattern[Byte]("^[0-9]+$")
+      implicit object ShortKeyPattern extends KeyPattern[Short]("^[0-9]+$")
+      implicit object IntKeyPattern extends KeyPattern[Int]("^[0-9]+$")
+      implicit object LongKeyPattern extends KeyPattern[Long]("^[0-9]+$")
     }
   }
 
@@ -302,12 +302,12 @@ object Schema {
       }
     }
   }
-  final object `object` {
+  object `object` {
     sealed trait Free { this: `object`[_] =>
       type Type
       def strict: `object`[Type]
     }
-    final object Free {
+    object Free {
       def apply[T](): `object`[T] with Free = {
         new `object`[T](Set.empty) with Free {
           type Type = T
@@ -347,7 +347,7 @@ object Schema {
       def setReadOnly: Field[T] = withRWMode(RWMode.ReadOnly)
       def setWriteOnly: Field[T] = withRWMode(RWMode.WriteOnly)
     }
-    final object Field {
+    object Field {
       sealed trait RWMode
       object RWMode {
         case object ReadOnly extends RWMode
@@ -401,7 +401,7 @@ object Schema {
       sb append ")"
     }
   }
-  final object `enum` {
+  object `enum` {
     def of[T](tpe: Schema[_], x: Value, xs: Value*): `enum`[T] = new `enum`[T](tpe, (x +: xs).toSet)
     def of[T](x: T, xs: T*)(implicit va: ValueAdapter[T], vs: ValueSchema[T]): `enum`[vs.S] = {
       new `enum`[vs.S](
@@ -440,7 +440,7 @@ object Schema {
     }
     def discriminatedBy(x: String): Self = new `oneof`[T](subTypes, Some(x))
   }
-  final object `oneof` {
+  object `oneof` {
     def of[T](x: Schema[_], xs: Schema[_]*): `oneof`[T] = new `oneof`[T]((x +: xs).toSet, None)
   }
 
@@ -468,7 +468,7 @@ object Schema {
       sb append ")"
     }
   }
-  final object `allof` {
+  object `allof` {
     def of[T](x: Schema[_], xs: Schema[_]*): `allof`[T] = new `allof`[T]((x +: xs).toSet)
   }
 
@@ -535,7 +535,7 @@ object Schema {
     }
   }
 
-  final object `def` {
+  object `def` {
     def apply[T](tpe: Schema[_])(sig: => String): `def`[T] = tpe match {
       case `def`(originalSig, innerTpe) => `def`(originalSig, innerTpe)
       case `value-class`(innerTpe)      => `def`(sig, innerTpe)

--- a/core/src/main/scala/json/schema/Version.scala
+++ b/core/src/main/scala/json/schema/Version.scala
@@ -7,7 +7,7 @@ sealed trait Version {
 
 object Version {
 
-  final case object Raw extends Version {
+  case object Raw extends Version {
     def uri = ???
   }
 

--- a/core/src/main/scala/json/schema/validation/Instance.scala
+++ b/core/src/main/scala/json/schema/validation/Instance.scala
@@ -14,42 +14,42 @@ sealed abstract class Instance[S, V]()(implicit conv: V => Value) extends Produc
 
 object Instance {
 
-  final case object `multipleOf` extends Instance[Number, Number]()(num.apply)
+  case object `multipleOf` extends Instance[Number, Number]()(num.apply)
 
-  final case object `maximum` extends Instance[Number, Number]()(num.apply)
+  case object `maximum` extends Instance[Number, Number]()(num.apply)
 
-  final case object `minimum` extends Instance[Number, Number]()(num.apply)
+  case object `minimum` extends Instance[Number, Number]()(num.apply)
 
-  final case object `exclusiveMaximum` extends Instance[Number, Number]()(num.apply)
+  case object `exclusiveMaximum` extends Instance[Number, Number]()(num.apply)
 
-  final case object `exclusiveMinimum` extends Instance[Number, Number]()(num.apply)
+  case object `exclusiveMinimum` extends Instance[Number, Number]()(num.apply)
 
-  final case object `contentEncoding` extends Instance[String, String]()(str.apply)
+  case object `contentEncoding` extends Instance[String, String]()(str.apply)
 
-  final case object `contentMediaType` extends Instance[String, String]()(str.apply)
+  case object `contentMediaType` extends Instance[String, String]()(str.apply)
 
-  final case object `contentSchema` extends Instance[String, json.Schema[_]]()(AsValue.schema(_, Draft04())) // FIXME: shouldn't specify a Version at this level
+  case object `contentSchema` extends Instance[String, json.Schema[_]]()(AsValue.schema(_, Draft04())) // FIXME: shouldn't specify a Version at this level
 
-  final case object `maxLength` extends Instance[String, Int]()(num.apply)
+  case object `maxLength` extends Instance[String, Int]()(num.apply)
 
-  final case object `minLength` extends Instance[String, Int]()(num.apply)
+  case object `minLength` extends Instance[String, Int]()(num.apply)
 
-  final case object `pattern` extends Instance[String, String]()(str.apply)
+  case object `pattern` extends Instance[String, String]()(str.apply)
 
-  final case object `maxItems` extends Instance[Iterable[_], Int]()(num.apply)
+  case object `maxItems` extends Instance[Iterable[_], Int]()(num.apply)
 
-  final case object `minItems` extends Instance[Iterable[_], Int]()(num.apply)
+  case object `minItems` extends Instance[Iterable[_], Int]()(num.apply)
 
-  final case object `maxContains` extends Instance[Iterable[_], Int]()(num.apply)
+  case object `maxContains` extends Instance[Iterable[_], Int]()(num.apply)
 
-  final case object `minContains` extends Instance[Iterable[_], Int]()(num.apply)
+  case object `minContains` extends Instance[Iterable[_], Int]()(num.apply)
 
-  final case object `uniqueItems` extends Instance[Iterable[_], Boolean]()(bool.apply)
+  case object `uniqueItems` extends Instance[Iterable[_], Boolean]()(bool.apply)
 
-  final case object `maxProperties` extends Instance[Map[_, _], Int]()(num.apply)
+  case object `maxProperties` extends Instance[Map[_, _], Int]()(num.apply)
 
-  final case object `minProperties` extends Instance[Map[_, _], Int]()(num.apply)
+  case object `minProperties` extends Instance[Map[_, _], Int]()(num.apply)
 
-  final case object `patternProperties` extends Instance[Map[_, _], String]()(str.apply)
+  case object `patternProperties` extends Instance[Map[_, _], String]()(str.apply)
 }
 

--- a/macros/src/main/scala/com/github/andyglow/jsonschema/ScalaParts.scala
+++ b/macros/src/main/scala/com/github/andyglow/jsonschema/ScalaParts.scala
@@ -7,7 +7,7 @@ object ScalaParts {
     tpe: String,
     default: Option[String])
 
-  final object ParsedParameter {
+  object ParsedParameter {
 
     def fromString(x: String): ParsedParameter = {
       val colonIdx = x.indexOf(':')

--- a/macros/src/main/scala/com/github/andyglow/jsonschema/UCommons.scala
+++ b/macros/src/main/scala/com/github/andyglow/jsonschema/UCommons.scala
@@ -47,7 +47,7 @@ private[jsonschema] trait UCommons extends SchemaTypes with ULogging { this: UCo
     val Field      = q"$Schema.`object`.Field"
     val Predef     = q"$json.schema.Predef"
     val Validation = q"$json.schema.validation.Instance"
-    final object internal {
+    object internal {
       private val prefix = q"_root_.com.github.andyglow"
       val json = q"$prefix.json"
       val jsonschema = q"$prefix.jsonschema"

--- a/macros/src/main/scala/com/github/andyglow/jsonschema/UFieldDecorations.scala
+++ b/macros/src/main/scala/com/github/andyglow/jsonschema/UFieldDecorations.scala
@@ -14,7 +14,7 @@ trait UFieldDecorations { this: UContext with UCommons =>
     */
   type FieldDecorations = Map[String, String]
 
-  final object FieldDecorations {
+  object FieldDecorations {
 
     val Empty: FieldDecorations = Map.empty
 

--- a/modules/enumeratum/src/test/scala/com/github/andyglow/jsonschema/EnumeratumSupportSpec.scala
+++ b/modules/enumeratum/src/test/scala/com/github/andyglow/jsonschema/EnumeratumSupportSpec.scala
@@ -71,82 +71,82 @@ class EnumeratumSupportSpec extends AnyWordSpec {
 object EnumeratumSupportSpec {
 
   sealed trait E0 extends EnumEntry
-  final object E0 extends Enum[E0] {
-    final case object AaAa extends E0
-    final case object BbBb extends E0
-    final case object CcCc extends E0
+  object E0 extends Enum[E0] {
+    case object AaAa extends E0
+    case object BbBb extends E0
+    case object CcCc extends E0
     override def values = findValues
   }
 
   sealed abstract class E1(override val entryName: String) extends EnumEntry
-  final object E1 extends Enum[E1] {
-    final case object AaAa extends E1("a")
-    final case object BbBb extends E1("b")
-    final case object CcCc extends E1("c")
+  object E1 extends Enum[E1] {
+    case object AaAa extends E1("a")
+    case object BbBb extends E1("b")
+    case object CcCc extends E1("c")
     override def values = findValues
   }
 
   sealed trait E2 extends EnumEntry with Hyphencase
-  final object E2 extends Enum[E2] {
-    final case object AaAa extends E2
-    final case object BbBb extends E2
-    final case object CcCc extends E2
+  object E2 extends Enum[E2] {
+    case object AaAa extends E2
+    case object BbBb extends E2
+    case object CcCc extends E2
     override def values = findValues
   }
 
   sealed abstract class IntV(val value: Int) extends IntEnumEntry
-  final object IntV extends IntEnum[IntV] {
-    final case object AaAa extends IntV(0)
-    final case object BbBb extends IntV(1)
-    final case object CcCc extends IntV(2)
+  object IntV extends IntEnum[IntV] {
+    case object AaAa extends IntV(0)
+    case object BbBb extends IntV(1)
+    case object CcCc extends IntV(2)
     override def values = findValues
   }
 
   sealed abstract class LongV(val value: Long) extends LongEnumEntry
-  final object LongV extends LongEnum[LongV] {
-    final case object AaAa extends LongV(0L)
-    final case object BbBb extends LongV(1L)
-    final case object CcCc extends LongV(2L)
+  object LongV extends LongEnum[LongV] {
+    case object AaAa extends LongV(0L)
+    case object BbBb extends LongV(1L)
+    case object CcCc extends LongV(2L)
     override def values = findValues
   }
 
   sealed abstract class ByteV(val value: Byte) extends ByteEnumEntry
-  final object ByteV extends ByteEnum[ByteV] {
-    final case object AaAa extends ByteV(0)
-    final case object BbBb extends ByteV(1)
-    final case object CcCc extends ByteV(2)
+  object ByteV extends ByteEnum[ByteV] {
+    case object AaAa extends ByteV(0)
+    case object BbBb extends ByteV(1)
+    case object CcCc extends ByteV(2)
     override def values = findValues
   }
 
   sealed abstract class ShortV(val value: Short) extends ShortEnumEntry
-  final object ShortV extends ShortEnum[ShortV] {
-    final case object AaAa extends ShortV(0)
-    final case object BbBb extends ShortV(1)
-    final case object CcCc extends ShortV(2)
+  object ShortV extends ShortEnum[ShortV] {
+    case object AaAa extends ShortV(0)
+    case object BbBb extends ShortV(1)
+    case object CcCc extends ShortV(2)
     override def values = findValues
   }
 
   sealed abstract class CharV(val value: Char) extends CharEnumEntry
-  final object CharV extends CharEnum[CharV] {
-    final case object AaAa extends CharV('a')
-    final case object BbBb extends CharV('b')
-    final case object CcCc extends CharV('c')
+  object CharV extends CharEnum[CharV] {
+    case object AaAa extends CharV('a')
+    case object BbBb extends CharV('b')
+    case object CcCc extends CharV('c')
     override def values = findValues
   }
 
   sealed abstract class StringV(val value: String) extends StringEnumEntry
-  final object StringV extends StringEnum[StringV] {
-    final case object AaAa extends StringV("a1")
-    final case object BbBb extends StringV("b2")
-    final case object CcCc extends StringV("c3")
+  object StringV extends StringEnum[StringV] {
+    case object AaAa extends StringV("a1")
+    case object BbBb extends StringV("b2")
+    case object CcCc extends StringV("c3")
     override def values = findValues
   }
 
   sealed abstract class StringVWithAlias(val value: String) extends StringEnumEntry with AllowAlias
-  final object StringVWithAlias extends StringEnum[StringVWithAlias] {
-    final case object AaAa extends StringVWithAlias("q")
-    final case object BbBb extends StringVWithAlias("q")
-    final case object CcCc extends StringVWithAlias("z")
+  object StringVWithAlias extends StringEnum[StringVWithAlias] {
+    case object AaAa extends StringVWithAlias("q")
+    case object BbBb extends StringVWithAlias("q")
+    case object CcCc extends StringVWithAlias("z")
     override def values = findValues
   }
 }

--- a/modules/refined/src/test/scala/com.github.andyglow.jsonschema.refined/FsExample.scala
+++ b/modules/refined/src/test/scala/com.github.andyglow.jsonschema.refined/FsExample.scala
@@ -27,16 +27,16 @@ object FsExampleMsg {
 
   sealed trait FsType
   object FsType {
-    final case object ext3 extends FsType
-    final case object ext4 extends FsType
-    final case object btrfs extends FsType
+    case object ext3 extends FsType
+    case object ext4 extends FsType
+    case object btrfs extends FsType
   }
 
   sealed trait DiskType
   object DiskType {
-    final case object disk extends DiskType
-    final case object nfs extends DiskType
-    final case object tmpfs extends DiskType
+    case object disk extends DiskType
+    case object nfs extends DiskType
+    case object tmpfs extends DiskType
   }
 
   @discriminator sealed trait Storage

--- a/project/ScalaVer.scala
+++ b/project/ScalaVer.scala
@@ -5,11 +5,11 @@ sealed abstract class ScalaVer(val full: String)
 
 object ScalaVer {
 
-  final case object _211 extends ScalaVer("2.11.12")
+  case object _211 extends ScalaVer("2.11.12")
 
-  final case object _212 extends ScalaVer("2.12.15")
+  case object _212 extends ScalaVer("2.12.15")
 
-  final case object _213 extends ScalaVer("2.13.7")
+  case object _213 extends ScalaVer("2.13.7")
 
   val values: Seq[ScalaVer] = Set(_213, _212, _211).toSeq
 


### PR DESCRIPTION
prepare Scala 3

```
Welcome to Scala 3.1.0 (11.0.13, Java OpenJDK 64-Bit Server VM).
Type in expressions for evaluation. Or try :help.

scala> final object Foo
-- Warning:
1 |final object Foo
  |^^^^^
  |Modifier final is redundant for this definition
// defined object Foo
```