### PR TITLE
Include title and description for sum types inside companion object

### DIFF
--- a/api/src/test/scala/com/github/andyglow/jsonschema/SchemaMacroSpec.scala
+++ b/api/src/test/scala/com/github/andyglow/jsonschema/SchemaMacroSpec.scala
@@ -4,6 +4,7 @@ import json.{Json, Schema}
 import json.schema.validation.Instance._
 import json.Schema._
 import json.schema.Version.Raw
+import json.schema.{description, title}
 import org.scalatest.matchers.should.Matchers._
 import org.scalatest.wordspec.AnyWordSpec
 
@@ -156,6 +157,19 @@ class SchemaMacroSpec extends AnyWordSpec {
       Json.schema[FooBarInsideCompanion] shouldEqual `oneof`(Set(
         `object`(Field("foo", `number`[Double])),
         `object`(Field("bar", `number`[Double]))))
+    }
+
+    "generate schema for Sealed Trait subclasses defined inside of it's companion object and include sub-types annotations" in {
+      import `object`.Field
+
+      Json.schema[FooBarInsideCompanionWithAnnotations] shouldEqual `oneof`(Set(
+        `object`(Field("foo", `number`[Double]))
+          .withTitle("FooInsideCompanionWithAnnotationsTitle")
+          .withDescription("FooInsideCompanionWithAnnotationsDescription"),
+        `object`(Field("bar", `number`[Double]))
+          .withTitle("BarInsideCompanionWithAnnotationsTitle")
+          .withDescription("BarInsideCompanionWithAnnotationsDescription")
+      ))
     }
 
     "generate schema for hybrid Sealed Trait family" in {
@@ -324,6 +338,18 @@ sealed trait FooBarInsideCompanion
 object FooBarInsideCompanion {
   case class FooBarInsideCompanion1(foo: Double) extends FooBarInsideCompanion
   case class FooBarInsideCompanion2(bar: Double) extends FooBarInsideCompanion
+}
+
+
+sealed trait FooBarInsideCompanionWithAnnotations
+object FooBarInsideCompanionWithAnnotations {
+  @title("FooInsideCompanionWithAnnotationsTitle")
+  @description("FooInsideCompanionWithAnnotationsDescription")
+  case class FooInsideCompanionWithAnnotations(foo: Double) extends FooBarInsideCompanionWithAnnotations
+
+  @title("BarInsideCompanionWithAnnotationsTitle")
+  @description("BarInsideCompanionWithAnnotationsDescription")
+  case class BarInsideCompanionWithAnnotations(bar: Double) extends FooBarInsideCompanionWithAnnotations
 }
 
 sealed trait AnyFooBar extends Any

--- a/macros/src/main/scala/com/github/andyglow/jsonschema/USumTypes.scala
+++ b/macros/src/main/scala/com/github/andyglow/jsonschema/USumTypes.scala
@@ -17,6 +17,13 @@ private[jsonschema] trait USumTypes { this: UContext with UCommons with UValueTy
       isSupportedLeafSymbol(s)
     }
 
+    private def addTitleAndDescriptionToSubType(st:SchemaType, tpe:Type): SchemaType = {
+      val typeDeco = TypeAnnotations(tpe)
+      st.withExtra(st.extra.copy(
+        title = typeDeco.texts.flatMap(_.title),
+        description = typeDeco.texts.flatMap(_.description)))
+    }
+
     def resolveOneOf(tpe: Type)(implicit ctx: ResolutionContext): Option[U.OneOf] = {
       Some.when (isSealed(tpe)) {
         // get type annotation for the root type
@@ -40,7 +47,7 @@ private[jsonschema] trait USumTypes { this: UContext with UCommons with UValueTy
         val schemas = subTypes map { subTpe =>
           val subSchema = Implicit.getOrElse(subTpe, subTpe match {
             case ValueClass(st) => st
-            case CaseClass(st)  => st
+            case CaseClass(st)  => addTitleAndDescriptionToSubType(st,subTpe)
             case CaseObject(co) if
               { enumItems = enumExtractor.someResolved(Seq(co.sym)) getOrElse Seq.empty
                 enumItems.nonEmpty


### PR DESCRIPTION
When generating `oneOf` schema for sum types inside companion object, also include title and description provided from annotations to the subtypes